### PR TITLE
Update Makefile to include coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,4 +28,7 @@ endif
 lint: .golangci.yml
 	golangci-lint $(DEBUG_LINTERS) run $(LINT_PACKAGES)
 
+coverage:
+	go test -race -coverprofile=coverage.out -covermode=atomic ./...
+
 .PHONY: lint coverage test


### PR DESCRIPTION
Seems coverage action was missing in Makefile which was not covering test coverage

Fixes #134 